### PR TITLE
ci: pin abi and treesitter version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
   test:
     name: Test parser
     runs-on: ${{matrix.os}}
+    env:
+      TREE_SITTER_ABI_VERSION: 14
     strategy:
       fail-fast: false
       matrix:
@@ -46,6 +48,8 @@ jobs:
   fuzz:
     name: Fuzz scanner
     runs-on: ubuntu-latest
+    env:
+      TREE_SITTER_ABI_VERSION: 14
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up tree-sitter
         uses: tree-sitter/setup-action/cli@v2
+        with:
+          tree-sitter-ref: "0.25.3"
       - name: Run parser and binding tests
         uses: tree-sitter/parser-test-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up tree-sitter
         uses: tree-sitter/setup-action/cli@v2
         with:
-          tree-sitter-ref: "0.25.3"
+          tree-sitter-ref: "v0.25.3"
       - name: Run parser and binding tests
         uses: tree-sitter/parser-test-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
   github:
     uses: tree-sitter/workflows/.github/workflows/release.yml@main
     with:
+      abi-version: "14"
       generate: false
       attestations: true
   crates:
@@ -20,16 +21,19 @@ jobs:
     secrets:
       CARGO_REGISTRY_TOKEN: ${{secrets.CARGO_REGISTRY_TOKEN}}
     with:
+      abi-version: "14"
       generate: false
   pypi:
     uses: tree-sitter/workflows/.github/workflows/package-pypi.yml@main
     secrets:
       PYPI_API_TOKEN: ${{secrets.PYPI_API_TOKEN}}
     with:
+      abi-version: "14"
       generate: false
   npm:
     uses: tree-sitter/workflows/.github/workflows/package-npm.yml@main
     secrets:
       NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}
     with:
+      abi-version: "14"
       generate: false

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -11,3 +11,5 @@ jobs:
   regenerate:
     uses: tree-sitter/workflows/.github/workflows/regenerate.yml@main
     if: github.actor == 'dependabot[bot]'
+    with:
+      abi-version: "14"


### PR DESCRIPTION
stabilizing CI builds.
Next up: pin all these treesitter actions which change too much under-the-hood.