### PR TITLE
ci: ungroup dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,8 @@ updates:
       day: sunday
     commit-message:
       prefix: ci
-    labels: [dependencies]
-    open-pull-requests-limit: 1
-    groups:
-      actions:
-        patterns: ["*"]
+    labels:
+      - dependencies
 
   - package-ecosystem: npm
     versioning-strategy: increase
@@ -23,9 +20,6 @@ updates:
       prefix: build(deps)
     labels:
       - dependencies
-    groups:
-      npm:
-        patterns: ["*"]
 
   - package-ecosystem: cargo
     directory: /
@@ -36,9 +30,6 @@ updates:
       prefix: build(deps)
     labels:
       - dependencies
-    groups:
-      cargo:
-        patterns: ["*"]
 
   - package-ecosystem: pip
     directory: /
@@ -49,9 +40,6 @@ updates:
       prefix: build(deps)
     labels:
       - dependencies
-    groups:
-      pip:
-        patterns: ["*"]
 
   - package-ecosystem: swift
     directory: /
@@ -62,9 +50,6 @@ updates:
       prefix: build(deps)
     labels:
       - dependencies
-    groups:
-      swift:
-        patterns: ["*"]
 
   - package-ecosystem: gomod
     directory: /
@@ -75,6 +60,3 @@ updates:
       prefix: build(deps)
     labels:
       - dependencies
-    groups:
-      go:
-        patterns: ["*"]


### PR DESCRIPTION
More smaller PRs is better than huge ones