### PR TITLE
ci: run tsc

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,5 +29,7 @@ jobs:
           node-version: ${{env.NODE_VERSION}}
       - name: Install modules
         run: npm ci --legacy-peer-deps
+      - name: Run TSC
+        run: npm run typecheck
       - name: Run ESLint
         run: npm run lint

--- a/grammar.js
+++ b/grammar.js
@@ -396,7 +396,7 @@ module.exports = grammar({
     indexword: _ => /[a-zA-Z]+/,
 
     unsigned_integer: _ => /[0-9]+/,
-    identifier: _ => /[\p{XID_Start}_$][\p{XID_Continue}\u00A2_$]*/,
+    identifier: _ => /[\p{XID_Start}_$][\p{XID_Continue}\u00A2_$]*/u,
 
     literal: _ => /[^}]+/,
     code: $ => $._text,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "eslint-config-treesitter": "^1.0.2",
         "prebuildify": "^6.0.1",
         "tree-sitter": "^0.21.1",
-        "tree-sitter-cli": "^0.25.5"
+        "tree-sitter-cli": "^0.25.5",
+        "typescript": "^5.6.2"
       },
       "peerDependencies": {
         "tree-sitter": "^0.21.1"
@@ -1517,6 +1518,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "tree-sitter-cli": "^0.25.5",
     "tree-sitter": "^0.21.1",
     "eslint": "^9.17.0",
-    "eslint-config-treesitter": "^1.0.2"
+    "eslint-config-treesitter": "^1.0.2",
+    "typescript": "^5.6.2"
   },
   "peerDependencies": {
     "tree-sitter": "^0.21.1"
@@ -50,7 +51,8 @@
     "install": "node-gyp-build",
     "prestart": "tree-sitter build --wasm",
     "start": "tree-sitter playground",
-    "lint": "eslint grammar.js",
+    "lint": "eslint --max-warnings 0 grammar.js",
+    "typecheck": "tsc --noEmit",
     "test": "node --test bindings/node/*_test.js"
   }
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2089,7 +2089,8 @@
     },
     "identifier": {
       "type": "PATTERN",
-      "value": "[\\p{XID_Start}_$][\\p{XID_Continue}\\u00A2_$]*"
+      "value": "[\\p{XID_Start}_$][\\p{XID_Continue}\\u00A2_$]*",
+      "flags": "u"
     },
     "literal": {
       "type": "PATTERN",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "files": [
+    "grammar.js"
+  ],
+  "compilerOptions": {
+    "target": "es2024",
+    "skipLibCheck": true,
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedSideEffectImports": true
+  }
+}


### PR DESCRIPTION
In strict mode, it can find some bugs that eslint won't. Plus, this prevents warnings/errors in editors.