### PR TITLE
fix(python): use abi-14 since this is the max py-tree-sitter supports.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,39 @@ jobs:
         uses: tree-sitter/parser-test-action@d70d9d71114d35dda8e60e54604036a89f667a8c # v2
         with:
           test-go: true
-          test-python: true
+          # TODO: change to 'true' when py-tree-sitter supports it
+          test-python: false
           test-node: true
           test-rust: true
           # setup-swift fails GPG validation on linux
           test-swift: ${{runner.os == 'macOS'}}
           abi-version: ${{env.TREE_SITTER_ABI_VERSION}}
+
+  # TODO: remove when py-tree-sitter supports it
+  test-abi-14:
+    name: Test parser (python abi 14)
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-15]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up tree-sitter
+        uses: tree-sitter/setup-action/cli@cd96f2c296346c12cf539df3e5cd00102a1f2340 # v2
+        with:
+          tree-sitter-ref: ${{env.TREE_SITTER_VERSION}}
+      - name: Regenerate parser
+        run: tree-sitter generate
+        env:
+          TREE_SITTER_ABI_VERSION: 14
+      - name: Run parser and binding tests
+        uses: tree-sitter/parser-test-action@d70d9d71114d35dda8e60e54604036a89f667a8c # v2
+        with:
+          test-python: true
+          abi-version: 14
+
   fuzz:
     name: Fuzz scanner
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
         uses: tree-sitter/parser-test-action@d70d9d71114d35dda8e60e54604036a89f667a8c # v2
         with:
           test-python: true
+          # disable verification since we've intentionally regenerated for this purpose
+          generate: false
           abi-version: 14
 
   fuzz:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,8 +28,9 @@ jobs:
     secrets:
       PYPI_API_TOKEN: ${{secrets.PYPI_API_TOKEN}}
     with:
-      abi-version: "15"
-      generate: false
+      # TODO: change to 15 when py-tree-sitter supports it
+      abi-version: "14"
+      generate: true
   npm:
     uses: tree-sitter/workflows/.github/workflows/package-npm.yml@6a7388cecfbc00765d032b2fca8f8abbe092ae8d
     secrets:

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ _obj/
 dist/
 *.egg-info
 *.whl
+__pycache__
 
 # C artifacts
 *.a

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LANGUAGE_NAME := tree-sitter-javadoc
 HOMEPAGE_URL := https://github.com/rmuir/tree-sitter-javadoc
 VERSION := 0.1.1
 
-export TREE_SITTER_ABI_VERSION = 15
+export TREE_SITTER_ABI_VERSION ?= 15
 
 # repository
 SRC_DIR := src

--- a/bindings/python/tests/test_binding.py
+++ b/bindings/python/tests/test_binding.py
@@ -1,12 +1,23 @@
 from unittest import TestCase
 
-import tree_sitter
 import tree_sitter_javadoc
+
+from tree_sitter import Language, Parser
+
+
+def language():
+    return Language(tree_sitter_javadoc.language())
 
 
 class TestLanguage(TestCase):
     def test_can_load_grammar(self):
-        try:
-            tree_sitter.Language(tree_sitter_javadoc.language())
-        except Exception:
-            self.fail("Error loading Javadoc grammar")
+        _ = language()
+
+    def test_can_create_parser(self):
+        _ = Parser(language())
+
+    def test_can_parse_docs(self):
+        parser = Parser(language())
+        doc = "/** test */".encode()
+        tree = parser.parse(doc)
+        assert not tree.root_node.has_error


### PR DESCRIPTION
Fix python bindings to just work with 'pip install'.
Add a failing test that would have indicated the issue in CI.
Test python bindings against ABI 14 and publish ABI 14 wheels in pypi.