### PR TITLE
ci: invalidate uv cache if C code changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,12 @@ core = ["tree-sitter~=0.24"]
 [tool.cibuildwheel]
 build = "cp310-*"
 build-frontend = "build"
+
+[tool.uv]
+# invalid local cache if the C code changes
+cache-keys = [
+  { file = "pyproject.toml" },
+  { file = "setup.py" },
+  { file = "src/parser.c" },
+  { file = "src/scanner.c" },
+]


### PR DESCRIPTION
Local build of the project is used by injection_tests: it must be rebuilt if the parser or scanner code changes, to validate the most recent code.

https://docs.astral.sh/uv/concepts/cache/#dynamic-metadata