### PR TITLE
test(golang): improve binding tests to create a parser

### DIFF
--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -12,4 +12,19 @@ func TestCanLoadGrammar(t *testing.T) {
 	if language == nil {
 		t.Errorf("Error loading Javadoc grammar")
 	}
+
+	parser := tree_sitter.NewParser()
+	if parser == nil {
+		t.Errorf("Error creating Javadoc parser")
+	}
+
+	version_mismatch := parser.SetLanguage(language)
+	if version_mismatch != nil {
+		t.Errorf("Version mismatch creating Javadoc parser: %s", version_mismatch.Error())
+	}
+
+	tree := parser.Parse([]byte("/** example **/"), nil)
+	if tree.RootNode().HasError() {
+		t.Errorf("Error parsing Javadoc sample: %s", tree.RootNode().ToSexp())
+	}
 }


### PR DESCRIPTION
Similar issue as python bindings tests, out of box they only create a Language object, but won't detect ABI incompatibilities. Create a parser and look for the incompatibility error. Parse a document for good measure.