### PR TITLE
test: parse markdown comments from corpora in injection tests

### DIFF
--- a/injection_tests/README.md
+++ b/injection_tests/README.md
@@ -52,7 +52,3 @@ https://github.com/apache/lucene.git --branch releases/lucene/10.2.2
 * Ability to ignore certain patterns such as tests
 * No git submodules (can mess up cargo checkouts)
 * Produces diff of parse trees across corpora on pull requests
-
-## Limitations
-
-* Currently only old-style javadocs

--- a/injection_tests/src/injection_tester/tester.py
+++ b/injection_tests/src/injection_tester/tester.py
@@ -26,6 +26,9 @@ injection_query = Query(
     """
 ((block_comment) @injection.content
   (#match? @injection.content "^/[*][*][^*]"))
+
+((line_comment) @injection.content
+  (#match? @injection.content "^///[ ]"))
 """,
 )
 error_query = Query(


### PR DESCRIPTION
Unfortunately, all of the data in current corpora seem to be accidental `/// line comments`.